### PR TITLE
make key mappings optional

### DIFF
--- a/plugin/split-term.vim
+++ b/plugin/split-term.vim
@@ -1,5 +1,6 @@
 
 let s:force_vertical = exists('g:split_term_vertical') ? 1 : 0
+let s:map_keys = exists('g:disable_key_mappings') ? 0 : 1
 
 " utilities around neovim's :term
 
@@ -55,7 +56,9 @@ fun! s:openTerm(args, count, vertical)
   call s:openBuffer(a:count, direction)
   exe 'terminal' a:args
   exe 'startinsert'
-  call s:defineMaps()
+  if s:map_keys
+    call s:defineMaps()
+  endif
 endf
 
 command! -count -nargs=* Term call s:openTerm(<q-args>, <count>, 0)

--- a/readme.md
+++ b/readme.md
@@ -80,9 +80,12 @@ REPL.
   - `set splitright` will put the new window right of the current one when using `:VTerm`
   - `set splitbelow` will put the new window below the current one when using `:Term`
 
+- `g:disable_key_mappings` - disable key mappings of the plugin
+
 ## Mappings
 
-The plugin remaps specifically a few keys for a better terminal buffer experience.
+The plugin remaps specifically a few keys for a better terminal buffer experience. This
+behaviour can be disabled using `g:disable_key_mappings`.
 
 - `<Esc>` - Switch to normal mode (instead of `<C-\><C-n>`)
 - Bind Alt+hjkl, Ctrl+arrows to navigate through windows (eg. switching to buffer/windows left, right etc.)


### PR DESCRIPTION
> introduce `g:disable_key_mappings` configuration

Basically this need arises from using vi shortcuts in the terminal (zsh vi mode), so using `Esc` for escaping insert mode is not desirable in this case.

The default behaviour still does key mapping so this change is not a breaking change.

If you are not happy with the wording, I will be glad to change it.
