### PR TITLE
add options to set default height (for vertical split) or width (for horizontal) of newly opened terminal

### DIFF
--- a/plugin/split-term.vim
+++ b/plugin/split-term.vim
@@ -2,6 +2,7 @@
 let s:force_vertical = exists('g:split_term_vertical') ? 1 : 0
 let s:map_keys = exists('g:disable_key_mappings') ? 0 : 1
 let s:default_shell = exists('g:split_term_default_shell') ? g:split_term_default_shell : 0
+let s:default_height_width = exists('g:split_term_height') ? g:split_term_height : 25
 
 " utilities around neovim's :term
 
@@ -46,7 +47,7 @@ endfunction
 " specify the number of visible columns or rows.
 fun! s:openBuffer(count, vertical)
   let cmd = a:vertical ? 'vnew' : 'new'
-  let cmd = a:count ? a:count . cmd : cmd
+  let cmd = a:count ? a:count . cmd : s:default_height_width . cmd
   exe cmd
 endf
 

--- a/plugin/split-term.vim
+++ b/plugin/split-term.vim
@@ -2,7 +2,8 @@
 let s:force_vertical = exists('g:split_term_vertical') ? 1 : 0
 let s:map_keys = exists('g:disable_key_mappings') ? 0 : 1
 let s:default_shell = exists('g:split_term_default_shell') ? g:split_term_default_shell : 0
-let s:default_height_width = exists('g:split_term_height') ? g:split_term_height : 25
+let s:default_height = exists('g:split_term_height') ? string(g:split_term_height) : ''
+let s:default_width = exists('g:split_term_width') ? string(g:split_term_width) : ''
 
 " utilities around neovim's :term
 
@@ -47,7 +48,11 @@ endfunction
 " specify the number of visible columns or rows.
 fun! s:openBuffer(count, vertical)
   let cmd = a:vertical ? 'vnew' : 'new'
-  let cmd = a:count ? a:count . cmd : s:default_height_width . cmd
+  if cmd == 'vnew'
+    let cmd = a:count ? a:count . cmd : s:default_width . cmd
+  else
+    let cmd = a:count ? a:count . cmd : s:default_height . cmd
+  endif
   exe cmd
 endf
 

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,9 @@ let g:split_term_default_shell = "bash"
 
 `g:disable_key_mappings` - disable key mappings of the plugin
 
-`g:split_term_height` - set default height/width at which terminal will be open
+`g:split_term_height` - set default height at which horizontal terminal will be open
+
+`g:split_term_width` - set default width at which vertical terminal will be open
 
 ## Mappings
 

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,8 @@ let g:split_term_default_shell = "bash"
 
 `g:disable_key_mappings` - disable key mappings of the plugin
 
+`g:split_term_height` - set default height/width at which terminal will be open
+
 ## Mappings
 
 The plugin remaps specifically a few keys for a better terminal buffer experience. This


### PR DESCRIPTION
adds two options: 
```
g:split_term_height
g:split_term_width
```
to be set in configuration file